### PR TITLE
Issue #191 : Support peek() in dstream-api

### DIFF
--- a/dstream-api/src/main/java/io/dstream/BaseDStream.java
+++ b/dstream-api/src/main/java/io/dstream/BaseDStream.java
@@ -23,6 +23,7 @@ import java.util.stream.Stream;
 
 import io.dstream.SerializableStreamAssets.SerBinaryOperator;
 import io.dstream.SerializableStreamAssets.SerComparator;
+import io.dstream.SerializableStreamAssets.SerConsumer;
 import io.dstream.SerializableStreamAssets.SerFunction;
 import io.dstream.SerializableStreamAssets.SerPredicate;
 import io.dstream.support.Classifier;
@@ -312,6 +313,23 @@ interface BaseDStream<A, T> extends ExecutableDStream<A> {
 	 * @return new {@link DStream} of the same type
 	 */
 	DStream<A> sorted(SerComparator<? super A> comparator);
+
+	/**
+	 * Returns a stream consisting of the elements of this stream, additionally
+	 * performing the provided action on each element as elements are consumed
+	 * from the resulting stream provided by {@code SerConsumer}.
+	 * <br>
+	 * This operation is consistent with
+	 * <i>Stream.peek(Consumer)</i>.<br>
+	 * <br>
+	 * This is an <i>intermediate</i> operation.
+	 * <br>
+	 *
+	 * @param action is an non-interfering action to be performed
+	 *                 on the stream as they are consumed from the stream
+	 * @return new {@link DStream} of the same type
+	 */
+	DStream<A> peek(SerConsumer<? super A> action);
 
 	/**
 	 * Returns a {@link DStream} of Key/Value pairs, where values mapped from the individual

--- a/dstream-api/src/main/java/io/dstream/DStreamExecutionGraphBuilder.java
+++ b/dstream-api/src/main/java/io/dstream/DStreamExecutionGraphBuilder.java
@@ -32,6 +32,7 @@ import java.util.stream.StreamSupport;
 import io.dstream.DStreamInvocationChain.DStreamInvocation;
 import io.dstream.SerializableStreamAssets.SerBinaryOperator;
 import io.dstream.SerializableStreamAssets.SerComparator;
+import io.dstream.SerializableStreamAssets.SerConsumer;
 import io.dstream.SerializableStreamAssets.SerFunction;
 import io.dstream.function.BiFunctionToBinaryOperatorAdapter;
 import io.dstream.function.DStreamToStreamAdapterFunction;
@@ -144,6 +145,9 @@ final class DStreamExecutionGraphBuilder {
 		}
 		else if (Ops.isStreamComparator(operation)){
 			this.addStreamComparatorOperation(invocation);
+		}
+		else if (Ops.isStreamConsumer(operation)){
+			this.addStreamConsumerOperation(invocation);
 		}
 	}
 	
@@ -288,6 +292,19 @@ final class DStreamExecutionGraphBuilder {
 		SerComparator<?> comparator = invocation.getArguments().length == 1 ? (SerComparator<?>)invocation.getArguments()[0] : null ;
 		this.adjustCurrentStreamState();
 		DStreamToStreamAdapterFunction streamAdaperFunc = new DStreamToStreamAdapterFunction(invocation.getMethod().getName(), comparator);
+		this.currentStreamOperation.addStreamOperationFunction(invocation.getMethod().getName(), streamAdaperFunc);
+	}
+
+	/**
+	 *
+	 * @param invocation
+	 */
+	private void addStreamConsumerOperation(DStreamInvocation invocation){
+		SerConsumer<?> consumer = invocation.getArguments().length == 1 ? (SerConsumer<?>)invocation
+				.getArguments()[0] :
+				null ;
+		this.adjustCurrentStreamState();
+		DStreamToStreamAdapterFunction streamAdaperFunc = new DStreamToStreamAdapterFunction(invocation.getMethod().getName(), consumer);
 		this.currentStreamOperation.addStreamOperationFunction(invocation.getMethod().getName(), streamAdaperFunc);
 	}
 	

--- a/dstream-api/src/main/java/io/dstream/DStreamExecutionGraphsBuilder.java
+++ b/dstream-api/src/main/java/io/dstream/DStreamExecutionGraphsBuilder.java
@@ -54,7 +54,7 @@ final class DStreamExecutionGraphsBuilder<T,R> {
 	/**
 	 * 
 	 * @param sourceElementType
-	 * @param sourceProperty
+	 * @param sourceIdentifier
 	 * @param streamType
 	 * @return
 	 */

--- a/dstream-api/src/main/java/io/dstream/DStreamInvocationChain.java
+++ b/dstream-api/src/main/java/io/dstream/DStreamInvocationChain.java
@@ -97,7 +97,7 @@ final class DStreamInvocationChain {
 	
 	/**
 	 * 
-	 * @param invocation
+	 * @param invocations
 	 */
 	protected void addAllInvocations(List<DStreamInvocation> invocations){
 		this.invocations.addAll(invocations);
@@ -163,7 +163,7 @@ final class DStreamInvocationChain {
 		
 		/**
 		 * 
-		 * @param operation
+		 * @param supplementaryOperation
 		 */
 		protected void setSupplementaryOperation(Object supplementaryOperation) {
 			this.supplementaryOperation = supplementaryOperation;

--- a/dstream-api/src/main/java/io/dstream/Ops.java
+++ b/dstream-api/src/main/java/io/dstream/Ops.java
@@ -42,6 +42,7 @@ public enum Ops {
 	reduce,
 	reduceValues,
 	sorted,
+	peek,
 	union,
 	unionAll;
 	
@@ -76,6 +77,10 @@ public enum Ops {
 	public static boolean isStreamComparator(String operationName){
 		return isStreamComparator(Ops.valueOf(operationName));
 	}
+
+	public static boolean isStreamConsumer(String operationName) {
+		return isStreamConsumer(Ops.valueOf(operationName));
+	}
 	
 	/**
 	 * Returns <i>true</i> if the operation identified by the given {@link Ops} is 
@@ -87,6 +92,11 @@ public enum Ops {
 			   operation.equals(distinct) ||
 			   operation.equals(sorted);
 	}
+
+	public static boolean isStreamConsumer(Ops operation) {
+		return operation.equals(peek);
+	}
+
 	
 	/**
 	 * Returns <i>true</i> if the operation identified by the given {@link Ops} is 

--- a/dstream-api/src/main/java/io/dstream/SerializableStreamAssets.java
+++ b/dstream-api/src/main/java/io/dstream/SerializableStreamAssets.java
@@ -22,6 +22,7 @@ import java.util.Comparator;
 import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.BinaryOperator;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -82,4 +83,9 @@ public interface SerializableStreamAssets {
 	 * {@link Serializable} version of {@link Comparator}
 	 */
 	public static interface SerComparator<T> extends Comparator<T>, Serializable{}
+
+	/**
+	 * {@link Serializable} version of {@link Consumer}
+	 */
+	public static interface SerConsumer<T> extends Consumer<T>, Serializable{}
 }

--- a/dstream-api/src/main/java/io/dstream/function/DStreamToStreamAdapterFunction.java
+++ b/dstream-api/src/main/java/io/dstream/function/DStreamToStreamAdapterFunction.java
@@ -47,7 +47,8 @@ public class DStreamToStreamAdapterFunction implements SerFunction<Stream<?>, St
 			Ops.distinct,
 			Ops.min,
 			Ops.max,
-			Ops.sorted));
+			Ops.sorted,
+			Ops.peek));
 	
 	private final String streamOperationName;
 	

--- a/dstream-api/src/main/java/io/dstream/local/ri/LocalDStreamExecutionEngine.java
+++ b/dstream-api/src/main/java/io/dstream/local/ri/LocalDStreamExecutionEngine.java
@@ -101,7 +101,7 @@ final class LocalDStreamExecutionEngine {
 	/**
 	 *
 	 * @param streamOperation
-	 * @param mapPartitions
+	 * @param partition
 	 */
 	@SuppressWarnings("unchecked")
 	private void doExecuteStage(DStreamOperation streamOperation, boolean partition, String pipelineName){

--- a/dstream-api/src/test/java/io/dstream/local/ri/DStreamExecutionTests.java
+++ b/dstream-api/src/test/java/io/dstream/local/ri/DStreamExecutionTests.java
@@ -59,7 +59,23 @@ public class DStreamExecutionTests {
 		assertEquals("The ship drew on and had safely passed the strait, which some volcanic", p1Result.get(0));
 		assertEquals("shock has made between the Calasareigne and Jaros islands; had doubled", p1Result.get(1));
 	}
-	
+
+	@Test
+	public void noOperationsWithPeek() throws Exception {
+		Future<Stream<Stream<String>>> resultFuture = DStream.ofType(String.class, "wc")
+															 .peek(e -> System.out.println(" Peek-a-boo : " + e))
+															 .executeAs(EXECUTION_NAME);
+
+		Stream<Stream<String>> resultPartitionsStream = resultFuture.get();
+		List<Stream<String>> resultPartitionsList = resultPartitionsStream.collect(Collectors.toList());
+		assertEquals(2, resultPartitionsList.size());
+
+		// spot check
+		List<String> p1Result = resultPartitionsList.get(0).collect(Collectors.toList());
+		assertEquals("The ship drew on and had safely passed the strait, which some volcanic", p1Result.get(0));
+		assertEquals("shock has made between the Calasareigne and Jaros islands; had doubled", p1Result.get(1));
+	}
+
 	@Test
 	public void classifySource() throws Exception {
 		Future<Stream<Stream<String>>> resultFuture = DStream.ofType(String.class, "wc")
@@ -71,6 +87,23 @@ public class DStreamExecutionTests {
 		List<Stream<String>> resultPartitionsList = resultPartitionsStream.collect(Collectors.toList());
 		assertEquals(1, resultPartitionsList.size());
 		
+		// spot check
+		List<String> p1Result = resultPartitionsList.get(0).collect(Collectors.toList());
+		assertEquals("shock has made between the Calasareigne and Jaros islands; had doubled", p1Result.get(1));
+	}
+
+	@Test
+	public void classifySourceBeforeAndAfterPeek() throws Exception {
+		Future<Stream<Stream<String>>> resultFuture = DStream.ofType(String.class, "wc")
+															 .peek(e -> System.out.println("Before classify : " + e))
+															 .classify(record -> 1)
+															 .peek(e -> System.out.println("After classify : " + e))
+															 .executeAs(EXECUTION_NAME);
+
+		Stream<Stream<String>> resultPartitionsStream = resultFuture.get();
+		List<Stream<String>> resultPartitionsList = resultPartitionsStream.collect(Collectors.toList());
+		assertEquals(1, resultPartitionsList.size());
+
 		// spot check
 		List<String> p1Result = resultPartitionsList.get(0).collect(Collectors.toList());
 		assertEquals("shock has made between the Calasareigne and Jaros islands; had doubled", p1Result.get(1));
@@ -93,6 +126,26 @@ public class DStreamExecutionTests {
 		assertEquals("happened on board.", p1Result.get(0));
 		assertEquals("the ship drew on and had safely passed the strait, which some volcanic", p1Result.get(2));
 	}
+
+	@Test
+	public void classifyWithPriorTransformationAndPeekAfter() throws Exception {
+		Future<Stream<Stream<String>>> resultFuture = DStream.ofType(String.class, "wc")
+															 .peek(e -> System.out.println("Before map : " + e))
+															 .map(s -> s.toLowerCase())
+															 .peek(e -> System.out.println("After map : " + e))
+															 .classify(record -> record.substring(0, 1))
+															 .peek(e -> System.out.println("After classify : " + e))
+															 .executeAs(EXECUTION_NAME);
+
+		Stream<Stream<String>> resultPartitionsStream = resultFuture.get();
+		List<Stream<String>> resultPartitionsList = resultPartitionsStream.collect(Collectors.toList());
+		assertEquals(2, resultPartitionsList.size());
+
+		// spot check
+		List<String> p1Result = resultPartitionsList.get(0).collect(Collectors.toList());
+		assertEquals("happened on board.", p1Result.get(0));
+		assertEquals("the ship drew on and had safely passed the strait, which some volcanic", p1Result.get(2));
+	}
 	
 	@Test
 	public void classifyWithPriorKVProducingTransformation() throws Exception {
@@ -106,11 +159,34 @@ public class DStreamExecutionTests {
 		
 		List<Stream<Entry<String, Integer>>> resultPartitionsList = resultPartitionsStream.collect(Collectors.toList());
 		assertEquals(2, resultPartitionsList.size());
-		
+
 		// spot check
 		List<Entry<String, Integer>> p1Result = resultPartitionsList.get(0).collect(Collectors.toList());
 		assertEquals(KVUtils.kv("The ship drew on and had safely passed the strait, which some volcanic", 1), p1Result.get(0));
-		
+
+		List<Entry<String, Integer>> p2Result = resultPartitionsList.get(1).collect(Collectors.toList());
+		assertEquals(KVUtils.kv("Pomegue, and approached the harbor under topsails, jib, and spanker, but", 1), p2Result.get(0));
+	}
+
+	@Test
+	public void classifyWithPriorKVProducingTransformationWithPeek() throws Exception {
+		Future<Stream<Stream<Entry<String, Integer>>>> resultFuture = DStream.ofType(String.class, "wc")
+				.peek(e -> System.out.println("Before map : " + e))
+				.map(s -> KVUtils.kv(s, 1))
+				.peek(e -> System.out.println("After map : " + e))
+				.classify(entry -> entry.getKey().substring(0, 6))
+				.peek(e -> System.out.println("After classify : " + e))
+			.executeAs(EXECUTION_NAME);
+
+		Stream<Stream<Entry<String, Integer>>> resultPartitionsStream = resultFuture.get();
+
+		List<Stream<Entry<String, Integer>>> resultPartitionsList = resultPartitionsStream.collect(Collectors.toList());
+		assertEquals(2, resultPartitionsList.size());
+
+		// spot check
+		List<Entry<String, Integer>> p1Result = resultPartitionsList.get(0).collect(Collectors.toList());
+		assertEquals(KVUtils.kv("The ship drew on and had safely passed the strait, which some volcanic", 1), p1Result.get(0));
+
 		List<Entry<String, Integer>> p2Result = resultPartitionsList.get(1).collect(Collectors.toList());
 		assertEquals(KVUtils.kv("Pomegue, and approached the harbor under topsails, jib, and spanker, but", 1), p2Result.get(0));
 	}
@@ -133,6 +209,37 @@ public class DStreamExecutionTests {
 		List<Entry<String, Integer>> p2Result = resultPartitionsList.get(1).collect(Collectors.toList());
 		assertEquals(KVUtils.kv("evah dluoc enutrofsim tahw rehtona eno deksa ,live fo rennurerof eht", 1), p2Result.get(1));
 	}
+
+	@Test
+	public void classifyWithTransformationAfterClassificationWithPeek() throws Exception {
+		Future<Stream<Stream<Entry<String, Integer>>>> resultFuture = DStream.ofType(String.class, "wc")
+																			 .peek(e -> System.out
+																					 .println("Before map : " + e))
+																			 .map(s -> KVUtils.kv(s, 1))
+																			 .peek(e -> System.out
+																						 .println("After map : " + e))
+																			 .classify(entry -> entry.getKey()
+																									 .substring(0, 5))
+																			 .peek(e -> System.out
+																					 .println("After classify : " + e))
+																			 .map(entry -> KVUtils.kv(new StringBuilder(
+																							 entry.getKey()).reverse()
+																											.toString(),
+																					 entry.getValue()))
+																			 .peek(e -> System.out
+																					 .println("After map-2 : " + e))
+																			 .executeAs(EXECUTION_NAME);
+
+		Stream<Stream<Entry<String, Integer>>> resultPartitionsStream = resultFuture.get();
+
+		List<Stream<Entry<String, Integer>>> resultPartitionsList = resultPartitionsStream.collect(Collectors.toList());
+		assertEquals(2, resultPartitionsList.size());
+
+		// spot check
+		List<Entry<String, Integer>> p2Result = resultPartitionsList.get(1).collect(Collectors.toList());
+		assertEquals(KVUtils.kv("evah dluoc enutrofsim tahw rehtona eno deksa ,live fo rennurerof eht", 1),
+				p2Result.get(1));
+	}
 	
 	@Test
 	public void classifyAfterShuffleOperation() throws Exception {
@@ -147,7 +254,32 @@ public class DStreamExecutionTests {
 		
 		List<Stream<Entry<String, Integer>>> resultPartitionsList = resultPartitionsStream.collect(Collectors.toList());
 		assertEquals(1, resultPartitionsList.size());
-		
+
+		List<Entry<String, Integer>> p1Result = resultPartitionsList.get(0).collect(Collectors.toList());
+		assertEquals(KVUtils.kv("harbor", 1), p1Result.get(7));
+	}
+
+	@Test
+	public void classifyAfterShuffleOperationWithPeek() throws Exception {
+		Future<Stream<Stream<Entry<String, Integer>>>> resultFuture = DStream.ofType(String.class, "wc")
+																			 .peek(e -> System.out
+																					 .println("Before flatmap : " + e))
+																			 .flatMap(line -> Stream
+																					 .of(line.split("\\s+")))
+																			 .peek(e -> System.out
+																					 .println("After flatmap : " + e))
+																			 .reduceValues(s -> s, s -> 1, Integer::sum)
+																			 .peek(e -> System.out
+																					 .println("After reduceValues : " +
+																							 e))
+																			 .classify(entry -> 1).peek(e -> System.out
+						.println("After classify : " + e)).executeAs(EXECUTION_NAME);
+
+		Stream<Stream<Entry<String, Integer>>> resultPartitionsStream = resultFuture.get();
+
+		List<Stream<Entry<String, Integer>>> resultPartitionsList = resultPartitionsStream.collect(Collectors.toList());
+		assertEquals(1, resultPartitionsList.size());
+
 		List<Entry<String, Integer>> p1Result = resultPartitionsList.get(0).collect(Collectors.toList());
 		assertEquals(KVUtils.kv("harbor", 1), p1Result.get(7));
 	}
@@ -166,14 +298,43 @@ public class DStreamExecutionTests {
 		
 		List<Stream<Entry<String, List<Entry<String, Integer>>>>> resultPartitionsList = resultPartitionsStream.collect(Collectors.toList());
 		assertEquals(2, resultPartitionsList.size());
-		
+
 		// spot check
 		List<Entry<String, List<Entry<String, Integer>>>> p1Result = resultPartitionsList.get(0).collect(Collectors.toList());
 		assertEquals("b=[between=2, board.=1, but=1]", p1Result.get(3).toString());
 		assertEquals("j=[jib,=1]", p1Result.get(7).toString());
-		
+
 		List<Entry<String, List<Entry<String, Integer>>>> p2Result = resultPartitionsList.get(1).collect(Collectors.toList());
 		assertEquals("s=[safely=1, ship=1, shock=1, slowly=1, so=1, some=1, spanker,=1, sedately=1, strait,=1]", p2Result.get(7).toString());
+	}
+
+	@Test
+	public void classifyAfterShuffleAndShuffleAgainWithPeek() throws Exception {
+		Future<Stream<Stream<Entry<String, List<Entry<String, Integer>>>>>> resultFuture = DStream
+				.ofType(String.class, "wc").peek(e -> System.out.println("Before flatMap : " + e))
+				.flatMap(line -> Stream.of(line.split("\\s+"))).peek(e -> System.out.println("After flatmap : " + e))
+				.reduceValues(s -> s, s -> 1, Integer::sum).peek(e -> System.out.println("After reduceValues : " + e))
+				.classify(entry -> 1).peek(e -> System.out.println("After classify : " + e))
+				.aggregateValues(e -> e.getKey().substring(0, 1), e -> e)
+				.peek(e -> System.out.println("After aggregateValues : " + e)).executeAs(EXECUTION_NAME);
+
+		Stream<Stream<Entry<String, List<Entry<String, Integer>>>>> resultPartitionsStream = resultFuture.get();
+		//		ExecutionResultUtils.printResults(resultPartitionsStream, true);
+
+		List<Stream<Entry<String, List<Entry<String, Integer>>>>> resultPartitionsList = resultPartitionsStream
+				.collect(Collectors.toList());
+		assertEquals(2, resultPartitionsList.size());
+
+		// spot check
+		List<Entry<String, List<Entry<String, Integer>>>> p1Result = resultPartitionsList.get(0)
+																						 .collect(Collectors.toList());
+		assertEquals("b=[between=2, board.=1, but=1]", p1Result.get(3).toString());
+		assertEquals("j=[jib,=1]", p1Result.get(7).toString());
+
+		List<Entry<String, List<Entry<String, Integer>>>> p2Result = resultPartitionsList.get(1)
+																						 .collect(Collectors.toList());
+		assertEquals("s=[safely=1, ship=1, shock=1, slowly=1, so=1, some=1, spanker,=1, sedately=1, strait,=1]",
+				p2Result.get(7).toString());
 	}
 	
 	@Test
@@ -191,6 +352,37 @@ public class DStreamExecutionTests {
 		List<Stream<Entry<String, Integer>>> resultPartitionsList = resultPartitionsStream.collect(Collectors.toList());
 		assertEquals(2, resultPartitionsList.size());
 		
+		List<Entry<String, Integer>> p1Result = resultPartitionsList.get(0).collect(Collectors.toList());
+		assertEquals(KVUtils.kv("Calasareigne", 1), p1Result.get(0));
+		assertEquals(KVUtils.kv("asked", 1), p1Result.get(2));
+		assertEquals(KVUtils.kv("that", 2), p1Result.get(13));
+	}
+
+	@Test
+	public void subsequentClassifyWithPeek() throws Exception {
+		Future<Stream<Stream<Entry<String, Integer>>>> resultFuture = DStream.ofType(String.class, "wc")
+																			 .peek(e -> System.out
+																					 .println("Before flatMap : " + e))
+																			 .flatMap(line -> Stream
+																					 .of(line.split("\\s+")))
+																			 .peek(e -> System.out
+																					 .println("After flatMap : " + e))
+																			 .reduceValues(s -> s, s -> 1, Integer::sum)
+																			 .peek(e -> System.out
+																					 .println("After reduceValues : " + e))
+																			 .classify(s -> s.getKey().substring(0, 1))
+																			 .peek(e -> System.out
+																					 .println("After classify : " + e))
+																			 .classify(s -> s.getKey().substring(0, 2))
+																			 .peek(e -> System.out
+																					 .println("After classify - 2 : " +
+																							 e))
+																			 .executeAs(EXECUTION_NAME);
+
+		Stream<Stream<Entry<String, Integer>>> resultPartitionsStream = resultFuture.get();
+		List<Stream<Entry<String, Integer>>> resultPartitionsList = resultPartitionsStream.collect(Collectors.toList());
+		assertEquals(2, resultPartitionsList.size());
+
 		List<Entry<String, Integer>> p1Result = resultPartitionsList.get(0).collect(Collectors.toList());
 		assertEquals(KVUtils.kv("Calasareigne", 1), p1Result.get(0));
 		assertEquals(KVUtils.kv("asked", 1), p1Result.get(2));
@@ -237,12 +429,37 @@ public class DStreamExecutionTests {
 				.<String>compute(stream -> stream.map(s -> s.toUpperCase()))
 				.<String>compute(stream -> stream.map(s -> new StringBuilder(s).reverse().toString()))
 			.executeAs(EXECUTION_NAME);
-		
+
 		Stream<Stream<String>> resultPartitionsStream = resultFuture.get();
-		
+
 		List<Stream<String>> resultPartitionsList = resultPartitionsStream.collect(Collectors.toList());
 		assertEquals(2, resultPartitionsList.size());
-		
+
+		// spot check
+		List<String> p1Result = resultPartitionsList.get(0).collect(Collectors.toList());
+		assertEquals("CINACLOV EMOS HCIHW ,TIARTS EHT DESSAP YLEFAS DAH DNA NO WERD PIHS EHT", p1Result.get(0));
+	}
+
+	@Test
+	public void computeComputeWithPeek() throws Exception {
+		Future<Stream<Stream<String>>> resultFuture = DStream.ofType(String.class, "wc")
+															 .peek(e -> System.out.println("Before compute : " + e))
+															 .<String>compute(
+																	 stream -> stream.map(s -> s.toUpperCase()))
+															 .peek(e -> System.out
+																	 .println("After compute - uppercase" + " : " + e))
+															 .<String>compute(stream -> stream
+																	 .map(s -> new StringBuilder(s).reverse()
+																								   .toString()))
+															 .peek(e -> System.out
+																	 .println("After compute - reverse :" + " " + e))
+															 .executeAs(EXECUTION_NAME);
+
+		Stream<Stream<String>> resultPartitionsStream = resultFuture.get();
+
+		List<Stream<String>> resultPartitionsList = resultPartitionsStream.collect(Collectors.toList());
+		assertEquals(2, resultPartitionsList.size());
+
 		// spot check
 		List<String> p1Result = resultPartitionsList.get(0).collect(Collectors.toList());
 		assertEquals("CINACLOV EMOS HCIHW ,TIARTS EHT DESSAP YLEFAS DAH DNA NO WERD PIHS EHT", p1Result.get(0));
@@ -262,6 +479,30 @@ public class DStreamExecutionTests {
 		List<Stream<String>> resultPartitionsList = resultPartitionsStream.collect(Collectors.toList());
 		assertEquals(2, resultPartitionsList.size());
 		
+		// spot check
+		List<String> p1Result = resultPartitionsList.get(0).collect(Collectors.toList());
+		assertEquals(".DRAOB NO DENEPPAH", p1Result.get(2));
+	}
+
+	@Test
+	public void computeClassifyComputeWithPeek() throws Exception {
+		Future<Stream<Stream<String>>> resultFuture = DStream.ofType(String.class, "wc")
+															 .peek(e -> System.out.println("Before compute" + " : " +
+																	 e)).<String>compute(
+						stream -> stream.map(s -> s.toUpperCase()))
+															 .peek(e -> System.out.println("After compute" + " : " + e))
+															 .classify(s -> s.split(" ")[0].length())
+															 .peek(e -> System.out.println("After classify" + " : " +
+																	 e)).<String>compute(
+						stream -> stream.map(s -> new StringBuilder(s).reverse().toString()))
+															 .peek(e -> System.out.println("After compute" + " : " + e))
+															 .executeAs(EXECUTION_NAME);
+
+		Stream<Stream<String>> resultPartitionsStream = resultFuture.get();
+
+		List<Stream<String>> resultPartitionsList = resultPartitionsStream.collect(Collectors.toList());
+		assertEquals(2, resultPartitionsList.size());
+
 		// spot check
 		List<String> p1Result = resultPartitionsList.get(0).collect(Collectors.toList());
 		assertEquals(".DRAOB NO DENEPPAH", p1Result.get(2));
@@ -326,6 +567,30 @@ public class DStreamExecutionTests {
 		assertEquals(KVUtils.kv("ANOTHER", 1), p2Result.get(0));
 		assertEquals(KVUtils.kv("SEDATELY", 1), p2Result.get(7));
 	}
+
+	@Test
+	public void transformationAndShuffleWithPeek() throws Exception {
+		Future<Stream<Stream<Entry<String, Integer>>>> resultFuture = DStream.ofType(String.class, "wc").flatMap(
+				line -> Stream.of(line.split("\\s+"))).filter(word -> word.length() > 5).map(s -> s.toUpperCase())
+																			 .reduceValues(word -> word, word -> 1,
+																					 Integer::sum).peek(e -> System.out
+						.println("After " + "transformation shuffle :  " +
+								e)).executeAs(EXECUTION_NAME);
+
+		Stream<Stream<Entry<String, Integer>>> resultPartitionsStream = resultFuture.get();
+
+		List<Stream<Entry<String, Integer>>> resultPartitionsList = resultPartitionsStream.collect(Collectors.toList());
+		assertEquals(2, resultPartitionsList.size());
+
+		// spot check
+		List<Entry<String, Integer>> p1Result = resultPartitionsList.get(0).collect(Collectors.toList());
+		assertEquals(KVUtils.kv("BETWEEN", 2), p1Result.get(0));
+		assertEquals(KVUtils.kv("INSTINCT", 1), p1Result.get(4));
+
+		List<Entry<String, Integer>> p2Result = resultPartitionsList.get(1).collect(Collectors.toList());
+		assertEquals(KVUtils.kv("ANOTHER", 1), p2Result.get(0));
+		assertEquals(KVUtils.kv("SEDATELY", 1), p2Result.get(7));
+	}
 	
 	@Test
 	public void reduceSource() throws Exception {
@@ -354,6 +619,24 @@ public class DStreamExecutionTests {
 		Stream<Stream<String>> resultPartitionsStream = resultFuture.get();
 //		ExecutionResultUtils.printResults(resultPartitionsStream, true);
 		
+		List<Stream<String>> resultPartitionsList = resultPartitionsStream.collect(Collectors.toList());
+		assertEquals(1, resultPartitionsList.size());
+
+		List<String> p1Result = resultPartitionsList.get(0).collect(Collectors.toList());
+		assertEquals(1, p1Result.size());
+		assertTrue(p1Result.get(0).startsWith("Theshipdrewonandhadsafelypassedthestrait,whichsomevolcanicshockhas"));
+	}
+
+	@Test
+	public void reduceAfterTransformationWithPeek() throws Exception {
+		Future<Stream<Stream<String>>> resultFuture = DStream.ofType(String.class, "wc")
+															 .flatMap(s -> Stream.of(s.split("\\s+")))
+															 .reduce(String::concat).peek(e -> System.out
+						.println("After transformation reduce :  " + e)).executeAs(EXECUTION_NAME);
+
+		Stream<Stream<String>> resultPartitionsStream = resultFuture.get();
+		//		ExecutionResultUtils.printResults(resultPartitionsStream, true);
+
 		List<Stream<String>> resultPartitionsList = resultPartitionsStream.collect(Collectors.toList());
 		assertEquals(1, resultPartitionsList.size());
 
@@ -435,6 +718,24 @@ public class DStreamExecutionTests {
 		assertEquals(1, p1Result.size());
 		assertEquals(49L, (long)p1Result.get(0));
 	}
+
+	@Test
+	public void countAfterShuffleWithPeek() throws Exception {
+		Future<Stream<Stream<Long>>> resultFuture = DStream.ofType(String.class, "wc")
+														   .flatMap(s -> Stream.of(s.split("\\s+")))
+														   .reduceValues(s -> s, s -> 1, Integer::sum).count()
+														   .peek(e -> System.out.println("After count shuffle :  " + e))
+														   .executeAs(EXECUTION_NAME);
+
+		Stream<Stream<Long>> resultPartitionsStream = resultFuture.get();
+
+		List<Stream<Long>> resultPartitionsList = resultPartitionsStream.collect(Collectors.toList());
+		assertEquals(1, resultPartitionsList.size());
+
+		List<Long> p1Result = resultPartitionsList.get(0).collect(Collectors.toList());
+		assertEquals(1, p1Result.size());
+		assertEquals(49L, (long) p1Result.get(0));
+	}
 	
 	@Test
 	public void distinctSingleStage() throws Exception {
@@ -476,6 +777,30 @@ public class DStreamExecutionTests {
 		List<String> p1Result = resultPartitionsList.get(0).collect(Collectors.toList());
 		p1Result.stream().collect(Collectors.toMap(s -> s, s -> 1, Integer::sum)).values().forEach(count -> {
 			if (count > 1){
+				throw new IllegalStateException("value occures more then once");
+			}
+		});
+	}
+
+	@Test
+	public void distinctAfterShuffleWithPeek() throws Exception {
+		Future<Stream<Stream<String>>> resultFuture = DStream.ofType(String.class, "wc")
+															 .flatMap(s -> Stream.of(s.split("\\s+")))
+															 .classify(word -> word.length()).distinct()
+															 .peek(e -> System.out
+																	 .println("Distinct after shuffle :  " + e))
+															 .executeAs(EXECUTION_NAME);
+
+		Stream<Stream<String>> resultPartitionsStream = resultFuture.get();
+		//		ExecutionResultUtils.printResults(resultPartitionsStream, true);
+
+		List<Stream<String>> resultPartitionsList = resultPartitionsStream.collect(Collectors.toList());
+		assertEquals(2, resultPartitionsList.size());
+
+		// spot check
+		List<String> p1Result = resultPartitionsList.get(0).collect(Collectors.toList());
+		p1Result.stream().collect(Collectors.toMap(s -> s, s -> 1, Integer::sum)).values().forEach(count -> {
+			if (count > 1) {
 				throw new IllegalStateException("value occures more then once");
 			}
 		});
@@ -523,6 +848,29 @@ public class DStreamExecutionTests {
 		assertEquals(1, p2Result.size());
 		assertEquals("Calasareigne", p2Result.get(0));
 	}
+
+	@Test
+	public void minMaxAfterShuffleWithPeek() throws Exception {
+		Future<Stream<Stream<String>>> resultFuture = DStream.ofType(String.class, "wc")
+															 .flatMap(line -> Stream.of(line.split("\\s+")))
+															 .classify(s -> s).max(StringUtils::compareLength)
+															 .peek(e -> System.out
+																	 .println("After min max shuffle :  " + e))
+															 .executeAs(EXECUTION_NAME);
+
+		Stream<Stream<String>> resultPartitionsStream = resultFuture.get();
+
+		List<Stream<String>> resultPartitionsList = resultPartitionsStream.collect(Collectors.toList());
+		assertEquals(2, resultPartitionsList.size());
+
+		List<String> p1Result = resultPartitionsList.get(0).collect(Collectors.toList());
+		assertEquals(1, p1Result.size());
+		assertEquals("forerunner", p1Result.get(0));
+
+		List<String> p2Result = resultPartitionsList.get(1).collect(Collectors.toList());
+		assertEquals(1, p2Result.size());
+		assertEquals("Calasareigne", p2Result.get(0));
+	}
 	
 	@Test
 	public void sortedSingleStage() throws Exception {	
@@ -547,6 +895,31 @@ public class DStreamExecutionTests {
 		assertEquals("on", p2Result.get(0));
 		assertEquals("jib,", p2Result.get(18));
 		
+	}
+
+	@Test
+	public void sortedSingleStageWithPeek() throws Exception {
+		Future<Stream<Stream<String>>> resultFuture = DStream.ofType(String.class, "wc")
+															 .flatMap(line -> Stream.of(line.split("\\s+")))
+															 .sorted(StringUtils::compareLength)
+															 .peek(e -> System.out.println("After sorted :  " + e))
+															 .executeAs(EXECUTION_NAME);
+
+		Stream<Stream<String>> resultPartitionsStream = resultFuture.get();
+		//		ExecutionResultUtils.printResults(resultPartitionsStream, true);
+
+		List<Stream<String>> resultPartitionsList = resultPartitionsStream.collect(Collectors.toList());
+		assertEquals(2, resultPartitionsList.size());
+
+		// spot check
+		List<String> p1Result = resultPartitionsList.get(0).collect(Collectors.toList());
+		assertEquals("so", p1Result.get(0));
+		assertEquals("asked", p1Result.get(13));
+
+		List<String> p2Result = resultPartitionsList.get(1).collect(Collectors.toList());
+		assertEquals("on", p2Result.get(0));
+		assertEquals("jib,", p2Result.get(18));
+
 	}
 	
 	@Test
@@ -593,6 +966,24 @@ public class DStreamExecutionTests {
 		Stream<Stream<String>> resultPartitionsStream = resultFuture.get();
 		ExecutionResultUtils.printResults(resultPartitionsStream, true);
 	}
+
+	@Test
+	public void mapPartitionsWithPeek() throws Exception {
+		Future<Stream<Stream<String>>> resultFuture = DStream.ofType(String.class, "wc")
+															 .flatMap(line -> Stream.of(line.split("\\s+")))
+															 .reduceValues(s -> s, s -> 1, Integer::sum).map(s -> {
+					if (s.getKey().equals("happened")) {
+						assertEquals(1, PartitionIdHelper.getPartitionId());
+					} else if (s.getKey().equals("spanker")) {
+						assertEquals(0, PartitionIdHelper.getPartitionId());
+					}
+					return s.getKey();
+				}).peek(e -> System.out.println("map partitions :  " + e))
+															 .executeAs(EXECUTION_NAME);
+
+		Stream<Stream<String>> resultPartitionsStream = resultFuture.get();
+		ExecutionResultUtils.printResults(resultPartitionsStream, true);
+	}
 	
 	@Test
 	public void transformationShuffleTransformationShuffle() throws Exception {
@@ -617,6 +1008,40 @@ public class DStreamExecutionTests {
 		
 		List<Entry<Integer, List<String>>> p2Result = resultPartitionsList.get(1).collect(Collectors.toList());
 		assertEquals("1=[ANOTHER, APPROACHED, CALASAREIGNE, DOUBLED, FORERUNNER, HAPPENED, IDLERS,, INSTINCT, ISLANDS;, MISFORTUNE, POMEGUE,, SEDATELY, SPANKER,, STRAIT,, TOPSAILS,, VOLCANIC]", p2Result.get(0).toString());
+	}
+
+	@Test
+	public void transformationShuffleTransformationShuffleWithPeek() throws Exception {
+		Future<Stream<Stream<Entry<Integer, List<String>>>>> resultFuture = DStream.ofType(String.class, "wc").flatMap(
+				line -> Stream.of(line.split("\\s+"))).filter(word -> word.length() > 5).map(s -> s.toUpperCase())
+																				   .reduceValues(word -> word,
+																						   word -> 1, Integer::sum)
+																				   .filter(entry ->
+																						   entry.getKey().length() > 6)
+																				   .aggregateValues(
+																						   entry -> entry.getValue(),
+																						   entry -> entry.getKey())
+																				   .map(s -> {
+																					   Collections.sort(s.getValue());
+																					   return s;
+																				   }).peek(e -> System.out
+						.println("transformation shuffle " + "transformation " + "shuffle :  " + e))
+																				   .executeAs(EXECUTION_NAME);
+
+		Stream<Stream<Entry<Integer, List<String>>>> resultPartitionsStream = resultFuture.get();
+		//		ExecutionResultUtils.printResults(resultPartitionsStream, true);
+		List<Stream<Entry<Integer, List<String>>>> resultPartitionsList = resultPartitionsStream
+				.collect(Collectors.toList());
+		assertEquals(2, resultPartitionsList.size());
+
+		// spot check
+		List<Entry<Integer, List<String>>> p1Result = resultPartitionsList.get(0).collect(Collectors.toList());
+		assertEquals("2=[BETWEEN]", p1Result.get(0).toString());
+
+		List<Entry<Integer, List<String>>> p2Result = resultPartitionsList.get(1).collect(Collectors.toList());
+		assertEquals(
+				"1=[ANOTHER, APPROACHED, CALASAREIGNE, DOUBLED, FORERUNNER, HAPPENED, IDLERS,, INSTINCT, ISLANDS;, MISFORTUNE, POMEGUE,, SEDATELY, SPANKER,, STRAIT,, TOPSAILS,, VOLCANIC]",
+				p2Result.get(0).toString());
 	}
 	
 	@Test(expected=IllegalStateException.class)
@@ -702,6 +1127,30 @@ public class DStreamExecutionTests {
 		List<Tuple2<String, String>> p2Result = resultPartitionsList.get(1).collect(Collectors.toList());
 		assertEquals("[3 Hortonworks, Arun Murthy 3]", p2Result.get(6).toString());
 	}
+
+	@Test
+	public void twoWayJoinWithPredicateAndClassifierWithPeek() throws Exception {
+		DStream<String> one = DStream.ofType(String.class, "one").classify(a -> a.split("\\s+")[0]);
+		DStream<String> two = DStream.ofType(String.class, "two").classify(a -> a.split("\\s+")[2]);
+
+		Future<Stream<Stream<Tuple2<String, String>>>> resultFuture = one
+				.join(two).on(
+						tuple2 -> tuple2._1().substring(0, 1).equals(tuple2._2().substring(tuple2._2().length() - 1)))
+				.peek(e -> System.out.println("twoWay Join With PredicateAndClassifier :  "+ e))
+				.executeAs(EXECUTION_NAME);
+
+		Stream<Stream<Tuple2<String, String>>> resultPartitionsStream = resultFuture.get();
+//		ExecutionResultUtils.printResults(resultPartitionsStream, true);
+		List<Stream<Tuple2<String, String>>> resultPartitionsList = resultPartitionsStream.collect(Collectors.toList());
+		assertEquals(2, resultPartitionsList.size());
+
+		// spot check
+		List<Tuple2<String, String>> p1Result = resultPartitionsList.get(0).collect(Collectors.toList());
+		assertEquals("[2 Amazon, Jeff Bezos 2]", p1Result.get(0).toString());
+
+		List<Tuple2<String, String>> p2Result = resultPartitionsList.get(1).collect(Collectors.toList());
+		assertEquals("[3 Hortonworks, Arun Murthy 3]", p2Result.get(6).toString());
+	}
 	
 	@Test
 	public void twoWayJoinWithPredicateAndNoClassifier() throws Exception {
@@ -744,6 +1193,35 @@ public class DStreamExecutionTests {
 	}
 
 	@Test
+	public void threeWayJoinWithPredicateSinglePartitionWithPeek() throws Exception {
+		DStream<String> one = DStream.ofType(String.class, "one");
+		DStream<String> two = DStream.ofType(String.class, "two");
+		DStream<String> three = DStream.ofType(String.class, "three");
+
+		Future<Stream<Stream<Tuple3<String, String, String>>>> resultFuture = one.join(two).join(three).on(tuple3 ->
+				tuple3._1().substring(0, 1).equals(tuple3._2().substring(tuple3._2().length() - 1)) && tuple3._3()
+																											 .startsWith(
+																													 "The"))
+																				 .peek(e -> System.out.println(
+																						 "three way join with "
+																								 + "predicate single partition : "
+																								 + e))
+																				 .executeAs(EXECUTION_NAME + "-1");
+
+		Stream<Stream<Tuple3<String, String, String>>> resultPartitionsStream = resultFuture.get();
+		//		ExecutionResultUtils.printResults(resultPartitionsStream, true);
+		List<Stream<Tuple3<String, String, String>>> resultPartitionsList = resultPartitionsStream
+				.collect(Collectors.toList());
+		assertEquals(1, resultPartitionsList.size());
+
+		// spot check
+		List<Tuple3<String, String, String>> p1Result = resultPartitionsList.get(0).collect(Collectors.toList());
+		assertEquals(
+				"[1 Oracle, Thomas Kurian 1, The ship drew on and had safely passed the strait, which some volcanic]",
+				p1Result.get(1).toString());
+	}
+
+	@Test
 	public void fourWayJoinWithIntermediateTransformations() throws Exception {
 		DStream<String> one = DStream.ofType(String.class, "one").classify(a -> a.split("\\s+")[0]);
 		DStream<String> two = DStream.ofType(String.class, "two").classify(a -> a.split("\\s+")[2]);
@@ -776,6 +1254,41 @@ public class DStreamExecutionTests {
 		
 		assertTrue(resultPartitionsList.get(0).collect(Collectors.toList()).isEmpty());
 	}
+
+	@Test
+	public void fourWayJoinWithIntermediateTransformationsWithPeek() throws Exception {
+		DStream<String> one = DStream.ofType(String.class, "one").classify(a -> a.split("\\s+")[0]);
+		DStream<String> two = DStream.ofType(String.class, "two").classify(a -> a.split("\\s+")[2]);
+		DStream<String> three = DStream.ofType(String.class, "three").classify(a -> a.split("\\s+")[0]);
+		DStream<String> four = DStream.ofType(String.class, "four").classify(a -> a.split("\\s+")[0]);
+
+		Future<Stream<Stream<Tuple4<String, String, String, String>>>> resultFuture = one
+				.join(two)
+				.filter(t2 -> t2._1().contains("Hortonworks"))
+				.map(t2 -> tuple2(t2._1().toUpperCase(), t2._2().toUpperCase()))
+				.join(three)
+				.join(four).on(t3 -> {
+					String v1 = t3._1()._1().split("\\s+")[0];
+					String v2 = t3._1()._2().split("\\s+")[2];
+					String v3 = t3._2().split("\\s+")[0];
+					String v4 = t3._3().split("\\s+")[0];
+					return v1.equals(v2) && v1.equals(v3) && v1.equals(v4);
+				})
+				 .map(t3 -> tuple4(t3._1()._1(), t3._1()._2(), t3._2(), t3._3()))
+				.peek(e -> System.out.println("After map : " + e))
+				.executeAs(EXECUTION_NAME);
+
+		Stream<Stream<Tuple4<String, String, String, String>>> resultPartitionsStream = resultFuture.get();
+//		ExecutionResultUtils.printResults(resultPartitionsStream, true);
+		List<Stream<Tuple4<String, String, String, String>>> resultPartitionsList = resultPartitionsStream.collect(Collectors.toList());
+		assertEquals(2, resultPartitionsList.size());
+
+		// spot check
+		List<Tuple4<String, String, String, String>> p2Result = resultPartitionsList.get(1).collect(Collectors.toList());
+		assertEquals("[3 HORTONWORKS, ROB BEARDEN 3, 3 $1B, 3 5470 Great America Parkway Santa Clara, CA 95054]", p2Result.get(0).toString());
+
+		assertTrue(resultPartitionsList.get(0).collect(Collectors.toList()).isEmpty());
+	}
 	
 	@Test
 	public void unionDistinctSinglePartition() throws Exception {
@@ -796,6 +1309,28 @@ public class DStreamExecutionTests {
 		assertEquals(4, p1Result.size());
 		assertEquals("You have to learn the rules of the game. ", p1Result.get(0).toString());
 		
+	}
+
+	@Test
+	public void unionDistinctSinglePartitionWithPeek() throws Exception {
+		DStream<String> one = DStream.ofType(String.class, "unone");
+		DStream<String> two = DStream.ofType(String.class, "untwo");
+
+		Future<Stream<Stream<String>>> resultFuture = one
+				.union(two)
+				.peek(e -> System.out.println("After union : " + e))
+				.executeAs(EXECUTION_NAME + "-1");
+
+		Stream<Stream<String>> resultPartitionsStream = resultFuture.get();
+//		ExecutionResultUtils.printResults(resultPartitionsStream, true);
+		List<Stream<String>> resultPartitionsList = resultPartitionsStream.collect(Collectors.toList());
+		assertEquals(1, resultPartitionsList.size());
+
+		// spot check
+		List<String> p1Result = resultPartitionsList.get(0).collect(Collectors.toList());
+		assertEquals(4, p1Result.size());
+		assertEquals("You have to learn the rules of the game. ", p1Result.get(0).toString());
+
 	}
 	
 	@Test
@@ -818,6 +1353,28 @@ public class DStreamExecutionTests {
 		assertEquals("You have to learn the rules of the game. ", p1Result.get(0).toString());
 		
 	}
+
+	@Test
+	public void unionAllSinglePartitionWithPeek() throws Exception {
+		DStream<String> one = DStream.ofType(String.class, "unone");
+		DStream<String> two = DStream.ofType(String.class, "untwo");
+
+		Future<Stream<Stream<String>>> resultFuture = one
+				.unionAll(two)
+				.peek(e -> System.out.println("After Union : " + e))
+				.executeAs(EXECUTION_NAME + "-1");
+
+		Stream<Stream<String>> resultPartitionsStream = resultFuture.get();
+//		ExecutionResultUtils.printResults(resultPartitionsStream, true);
+		List<Stream<String>> resultPartitionsList = resultPartitionsStream.collect(Collectors.toList());
+		assertEquals(1, resultPartitionsList.size());
+
+		// spot check
+		List<String> p1Result = resultPartitionsList.get(0).collect(Collectors.toList());
+		assertEquals(6, p1Result.size());
+		assertEquals("You have to learn the rules of the game. ", p1Result.get(0).toString());
+
+	}
 	
 	@Test
 	public void simpleTwoWayUnionWithClassifier() throws Exception {
@@ -832,7 +1389,27 @@ public class DStreamExecutionTests {
 //		ExecutionResultUtils.printResults(resultPartitionsStream, true);
 		List<Stream<String>> resultPartitionsList = resultPartitionsStream.collect(Collectors.toList());
 		assertEquals(2, resultPartitionsList.size());
-		
+
+		// spot check
+		List<String> p1Result = resultPartitionsList.get(0).collect(Collectors.toList());
+		assertEquals("2 Amazon", p1Result.get(0));
+		assertEquals("Jeff Bezos 2", p1Result.get(1));
+		assertEquals("Jeffrey Blackburn 2", p1Result.get(2));
+	}
+
+	@Test
+	public void simpleTwoWayUnionWithClassifierWithPeek() throws Exception {
+		DStream<String> one = DStream.ofType(String.class, "one").classify(a -> a.split("\\s+")[0]);
+		DStream<String> two = DStream.ofType(String.class, "two").classify(a -> a.split("\\s+")[2]);
+
+		Future<Stream<Stream<String>>> resultFuture = one.union(two)
+														 .peek(e -> System.out.println("After union two" + " : " + e))
+														 .executeAs(EXECUTION_NAME);
+
+		Stream<Stream<String>> resultPartitionsStream = resultFuture.get();
+		List<Stream<String>> resultPartitionsList = resultPartitionsStream.collect(Collectors.toList());
+		assertEquals(2, resultPartitionsList.size());
+
 		// spot check
 		List<String> p1Result = resultPartitionsList.get(0).collect(Collectors.toList());
 		assertEquals("2 Amazon", p1Result.get(0));
@@ -856,6 +1433,31 @@ public class DStreamExecutionTests {
 		List<Stream<String>> resultPartitionsList = resultPartitionsStream.collect(Collectors.toList());
 		assertEquals(1, resultPartitionsList.size());
 		
+		// spot check
+		List<String> p1Result = resultPartitionsList.get(0).collect(Collectors.toList());
+		assertEquals("1 Oracle", p1Result.get(0));
+		assertEquals("Thomas Kurian 1", p1Result.get(9).toString());
+	}
+
+	@Test
+	public void simpleThreeWayUnionSinglePartitionWithPeek() throws Exception {
+		DStream<String> one = DStream.ofType(String.class, "one");
+		DStream<String> two = DStream.ofType(String.class, "two");
+		DStream<String> three = DStream.ofType(String.class, "three");
+
+		Future<Stream<Stream<String>>> resultFuture = one.
+																 peek(e -> System.out
+																		 .println("Before union two : " + e)).union(two)
+														 .
+																 peek(e -> System.out.println("After union two :" + e))
+														 .union(three)
+														 .peek(e -> System.out.println("After union three : " + e))
+														 .executeAs(EXECUTION_NAME + "-1");
+
+		Stream<Stream<String>> resultPartitionsStream = resultFuture.get();
+		List<Stream<String>> resultPartitionsList = resultPartitionsStream.collect(Collectors.toList());
+		assertEquals(1, resultPartitionsList.size());
+
 		// spot check
 		List<String> p1Result = resultPartitionsList.get(0).collect(Collectors.toList());
 		assertEquals("1 Oracle", p1Result.get(0));


### PR DESCRIPTION
#### Summary :
[Java8 peek](https://docs.oracle.com/javase/8/docs/api/java/util/stream/Stream.html#peek-java.util.function.Consumer-)
Needed a way to debug and check on jobs running on stream.
Initial support for peek(). We can iterate on this.

Fixed some of the javadoc errors.

#### TestPlan :
JUnit Tests in `io.dstream.local.ri.DStreamExecutionTests`

#### Reviewers :
Oleg Zhurakousky

#### Reported-By :
Swathi V

#### SignedOff-By :
swatzdev@gmail.com